### PR TITLE
Update Java from Java8 to Java16

### DIFF
--- a/.github/workflows/spigot.yml
+++ b/.github/workflows/spigot.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt' # See 'Supported distributions' for available options
-          java-version: '8'
+          java-version: '16'
       - run: |
           curl -O https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
           java -jar -Xmx1024M BuildTools.jar


### PR DESCRIPTION
We can not build latest version of spigot using Java8. 